### PR TITLE
Add couple of potentially useful functions

### DIFF
--- a/src/SelectList.elm
+++ b/src/SelectList.elm
@@ -1,18 +1,18 @@
 module SelectList
     exposing
-        ( SelectList
-        , map
-        , mapBy
-        , Position(..)
-        , fromLists
-        , select
-        , prepend
+        ( Position(..)
+        , SelectList
+        , after
         , append
         , before
-        , after
+        , fromLists
+        , map
+        , mapBy
+        , prepend
+        , select
         , selected
-        , toList
         , singleton
+        , toList
         )
 
 {-| A `SelectList` is a nonempty list which always has exactly one element selected.
@@ -217,7 +217,7 @@ selectHelp isSelectable beforeList selectedElem afterList =
 
         ( first :: rest, _ ) ->
             if isSelectable first then
-                Just ( [], first, (rest ++ selectedElem :: afterList) )
+                Just ( [], first, rest ++ selectedElem :: afterList )
             else
                 case selectHelp isSelectable rest selectedElem afterList of
                     Nothing ->

--- a/src/SelectList.elm
+++ b/src/SelectList.elm
@@ -5,6 +5,7 @@ module SelectList
         , after
         , append
         , before
+        , decoder
         , fromList
         , fromLists
         , map
@@ -32,7 +33,14 @@ It is an example of a list [zipper](https://en.wikipedia.org/wiki/Zipper_(data_s
 
 @docs map, mapBy, Position, select, append, prepend
 
+
+## Decoding
+
+@docs decoder
+
 -}
+
+import Json.Decode
 
 
 {-| A nonempty list which always has exactly one element selected.
@@ -287,3 +295,20 @@ prepend list (SelectList beforeSel sel afterSel) =
 toList : SelectList a -> List a
 toList (SelectList beforeSel sel afterSel) =
     beforeSel ++ sel :: afterSel
+
+
+{-| -}
+decoder : Json.Decode.Decoder a -> Json.Decode.Decoder (SelectList a)
+decoder itemDecoder =
+    let
+        createSelectList =
+            \list ->
+                case fromList list of
+                    Just selectList ->
+                        Json.Decode.succeed selectList
+
+                    Nothing ->
+                        Json.Decode.fail "expected list with more than one element"
+    in
+    Json.Decode.list itemDecoder
+        |> Json.Decode.andThen createSelectList

--- a/src/SelectList.elm
+++ b/src/SelectList.elm
@@ -5,6 +5,7 @@ module SelectList
         , after
         , append
         , before
+        , fromList
         , fromLists
         , map
         , mapBy
@@ -19,7 +20,7 @@ module SelectList
 
 It is an example of a list [zipper](https://en.wikipedia.org/wiki/Zipper_(data_structure)).
 
-@docs SelectList, fromLists, singleton
+@docs SelectList, fromLists, fromList, singleton
 
 
 ## Reading
@@ -169,6 +170,22 @@ map transform (SelectList beforeSel sel afterSel) =
 fromLists : List a -> a -> List a -> SelectList a
 fromLists =
     SelectList
+
+
+{-| -}
+fromList : List a -> Maybe (SelectList a)
+fromList list =
+    let
+        ( maybeHead, maybeTail ) =
+            ( List.head list, List.tail list )
+    in
+    Maybe.map2
+        (\head ->
+            \tail ->
+                fromLists [] head tail
+        )
+        maybeHead
+        maybeTail
 
 
 {-| Change the selected element to the first one which passes a


### PR DESCRIPTION
Hi @rtfeldman - I've been using this package in a couple of projects recently, where I've found it useful (so thanks :slightly_smiling_face:). While using it I've found a couple of situations have reappeared, at least for my use cases:

- I want to get a `SelectList` from a `List`, without selecting a particular element, either because I don't care which this is or because I can immediately pipe this into `SelectList.select`; since not every `List` can be turned into a `SelectList` this operation can fail so should produce a `SelectList` wrapped in a `Maybe` (or equivalent).

- I want to decode a JSON array of some type straight into a `SelectList` of that type; similarly I either don't care which element is initially selected or can use `SelectList.select` to handle this.

This PR contains a couple of commits with functions to perform each of these operations. Both of these are reasonably trivial with the current API, but since I found I was repeating them across projects I thought I'd suggest them here.

If you don't think these fit here or are worth adding, then no problem. If you do, or think just one of them is, let me know and I can adjust appropriately and add docs and tests. Either way, thanks in advance.